### PR TITLE
bugfix resource ID type

### DIFF
--- a/fhir/resources/resource.py
+++ b/fhir/resources/resource.py
@@ -22,7 +22,7 @@ class Resource(fhirresourcemodel.FHIRResourceModel):
 
     resource_type = Field("Resource", const=True)
 
-    id: fhirtypes.String = Field(
+    id: fhirtypes.Id = Field(
         None,
         alias="id",
         title="Logical id of this artifact",


### PR DESCRIPTION
The ID type of the field `id` should be `Id` and not `String` as documented here: https://www.hl7.org/fhir/resource-definitions.html#Resource.id