### PR TITLE
WIP: Use fhirdatetime instead of Pydantic's datetime

### DIFF
--- a/fhir/resources/DSTU2/tests/test_allergyintolerance.py
+++ b/fhir/resources/DSTU2/tests/test_allergyintolerance.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from pydantic.datetime_parse import parse_date, parse_datetime
-
 from .. import fhirtypes  # noqa: F401
 from .. import allergyintolerance
 
@@ -43,7 +41,7 @@ def impl_AllergyIntolerance_1(inst):
     assert inst.identifier[0].system == "http://acme.com/ids/patients/risks"
     assert inst.identifier[0].value == "49476534"
     assert inst.patient.reference == "Patient/example"
-    assert inst.recordedDate == parse_datetime("2014-10-09T14:58:00+11:00")
+    assert inst.recordedDate.isoformat() == "2014-10-09T14:58:00+11:00"
     assert inst.recorder.reference == "Practitioner/example"
     assert inst.status == "refuted"
     assert inst.substance.coding[0].code == "227493005"
@@ -94,7 +92,7 @@ def impl_AllergyIntolerance_2(inst):
     assert (
         inst.reaction[0].manifestation[0].coding[0].system == "http://snomed.info/sct"
     )
-    assert inst.reaction[0].onset == parse_date("2012-06-12")
+    assert str(inst.reaction[0].onset) == "2012-06-12"
     assert inst.reaction[0].severity == "severe"
     assert inst.reaction[0].substance.coding[0].code == "C3214954"
     assert (
@@ -111,9 +109,9 @@ def impl_AllergyIntolerance_2(inst):
     assert (
         inst.reaction[1].manifestation[0].coding[0].system == "http://snomed.info/sct"
     )
-    assert inst.reaction[1].onset == "2004"
+    assert str(inst.reaction[1].onset) == "2004"
     assert inst.reaction[1].severity == "moderate"
-    assert inst.recordedDate == parse_datetime("2014-10-09T14:58:00+11:00")
+    assert inst.recordedDate.isoformat() == "2014-10-09T14:58:00+11:00"
     assert inst.recorder.reference == "Practitioner/example"
     assert inst.status == "confirmed"
     assert inst.substance.coding[0].code == "227493005"
@@ -152,7 +150,7 @@ def impl_AllergyIntolerance_3(inst):
     assert inst.identifier[0].system == "http://acme.com/ids/patients/risks"
     assert inst.identifier[0].value == "49476535"
     assert inst.patient.reference == "Patient/example"
-    assert inst.recordedDate == parse_datetime("2015-08-06T15:37:31-06:00")
+    assert inst.recordedDate.isoformat() == "2015-08-06T15:37:31-06:00"
     assert inst.recorder.reference == "Practitioner/example"
     assert inst.substance.coding[0].code == "227037002"
     assert inst.substance.coding[0].display == "Fish - dietary (substance)"
@@ -198,7 +196,7 @@ def impl_AllergyIntolerance_4(inst):
     assert (
         inst.reaction[0].manifestation[0].coding[0].system == "http://snomed.info/sct"
     )
-    assert inst.recordedDate == parse_date("2010-03-01")
+    assert str(inst.recordedDate) == "2010-03-01"
     assert inst.recorder.reference == "Practitioner/13"
     assert inst.status == "unconfirmed"
     assert inst.substance.coding[0].code == "314422"

--- a/fhir/resources/STU3/fhirtypes.py
+++ b/fhir/resources/STU3/fhirtypes.py
@@ -5,6 +5,7 @@ from email.utils import formataddr, parseaddr
 from typing import TYPE_CHECKING, Any, Dict, Optional, Pattern, Union
 from uuid import UUID
 
+from fhirdatetime import FhirDateTime
 from pydantic import AnyUrl
 from pydantic.errors import DateError, DateTimeError, TimeError
 from pydantic.main import load_str_bytes
@@ -16,7 +17,7 @@ from pydantic.types import (
     ConstrainedInt,
     ConstrainedStr,
 )
-from pydantic.validators import bool_validator, parse_date, parse_datetime, parse_time
+from pydantic.validators import bool_validator, parse_time
 
 from .fhirabstractmodel import FHIRAbstractModel
 from .fhirtypesvalidators import run_validator_for_fhir_type
@@ -289,7 +290,7 @@ class Xhtml(ConstrainedStr, Primitive):
     __visit_name__ = "xhtml"
 
 
-class Date(datetime.date, Primitive):
+class Date(FhirDateTime, Primitive):
     """A date, or partial date (e.g. just year or year + month)
     as used in human communication. The format is YYYY, YYYY-MM, or YYYY-MM-DD,
     e.g. 2018, 1973-06, or 1905-08-23.
@@ -309,12 +310,12 @@ class Date(datetime.date, Primitive):
 
     @classmethod
     def validate(
-        cls, value: Union[datetime.date, str, bytes, int, float]
-    ) -> Union[datetime.date, str]:
+        cls, value: Union[FhirDateTime, datetime.date, str, bytes, int, float]
+    ) -> FhirDateTime:
         """ """
         if not isinstance(value, str):
             # default handler
-            return parse_date(value)
+            return FhirDateTime(value)
 
         match = FHIR_DATE_PARTS.match(value)
 
@@ -324,12 +325,10 @@ class Date(datetime.date, Primitive):
         elif not match.groupdict().get("day"):
             if match.groupdict().get("month") and int(match.groupdict()["month"]) > 12:
                 raise DateError()
-            # we keep original
-            return value
-        return parse_date(value)
+        return FhirDateTime(value)
 
 
-class DateTime(datetime.datetime, Primitive):
+class DateTime(FhirDateTime, Primitive):
     """A date, date-time or partial date (e.g. just year or year + month) as used
     in human communication. The format is YYYY, YYYY-MM, YYYY-MM-DD or
     YYYY-MM-DDThh:mm:ss+zz:zz, e.g. 2018, 1973-06, 1905-08-23,
@@ -356,15 +355,15 @@ class DateTime(datetime.datetime, Primitive):
 
     @classmethod
     def validate(
-        cls, value: Union[datetime.date, datetime.datetime, str, bytes, int, float]
-    ) -> Union[datetime.datetime, datetime.date, str]:
+        cls,
+        value: Union[
+            FhirDateTime, datetime.date, datetime.datetime, str, bytes, int, float
+        ],
+    ) -> FhirDateTime:
         """ """
-        if isinstance(value, datetime.date):
-            return value
-
-        if not isinstance(value, str):
+        if isinstance(value, datetime.date) or not isinstance(value, str):
             # default handler
-            return parse_datetime(value)
+            return FhirDateTime(value)
         match = FHIR_DATE_PARTS.match(value)
         if match:
             if (
@@ -372,19 +371,17 @@ class DateTime(datetime.datetime, Primitive):
                 and match.groupdict().get("month")
                 and match.groupdict().get("day")
             ):
-                return parse_date(value)
+                return FhirDateTime(value)
             elif match.groupdict().get("year") and match.groupdict().get("month"):
                 if int(match.groupdict()["month"]) > 12:
                     raise DateError()
-            # we don't want to loose actual information, so keep as string
-            return value
         if not cls.regex.match(value):
             raise DateTimeError()
 
-        return parse_datetime(value)
+        return FhirDateTime(value)
 
 
-class Instant(datetime.datetime, Primitive):
+class Instant(FhirDateTime, Primitive):
     """An instant in time in the format YYYY-MM-DDThh:mm:ss.sss+zz:zz
     (e.g. 2015-02-07T13:28:17.239+02:00 or 2017-01-01T00:00:00Z).
     The time SHALL specified at least to the second and SHALL include a time zone.
@@ -410,12 +407,12 @@ class Instant(datetime.datetime, Primitive):
         yield cls.validate
 
     @classmethod
-    def validate(cls, value):
+    def validate(cls, value) -> FhirDateTime:
         """ """
         if isinstance(value, str):
             if not cls.regex.match(value):
                 raise DateTimeError()
-        return parse_datetime(value)
+        return FhirDateTime(value)
 
 
 class Time(datetime.time, Primitive):

--- a/fhir/resources/fhirtypes.py
+++ b/fhir/resources/fhirtypes.py
@@ -5,6 +5,7 @@ from email.utils import formataddr, parseaddr
 from typing import TYPE_CHECKING, Any, Dict, Optional, Pattern, Union
 from uuid import UUID
 
+from fhirdatetime import FhirDateTime
 from pydantic import AnyUrl
 from pydantic.errors import DateError, DateTimeError, TimeError
 from pydantic.main import load_str_bytes
@@ -16,7 +17,7 @@ from pydantic.types import (
     ConstrainedInt,
     ConstrainedStr,
 )
-from pydantic.validators import bool_validator, parse_date, parse_datetime, parse_time
+from pydantic.validators import bool_validator, parse_time
 
 from .fhirabstractmodel import FHIRAbstractModel
 from .fhirtypesvalidators import run_validator_for_fhir_type
@@ -289,7 +290,7 @@ class Xhtml(ConstrainedStr, Primitive):
     __visit_name__ = "xhtml"
 
 
-class Date(datetime.date, Primitive):
+class Date(FhirDateTime, Primitive):
     """A date, or partial date (e.g. just year or year + month)
     as used in human communication. The format is YYYY, YYYY-MM, or YYYY-MM-DD,
     e.g. 2018, 1973-06, or 1905-08-23.
@@ -309,12 +310,12 @@ class Date(datetime.date, Primitive):
 
     @classmethod
     def validate(
-        cls, value: Union[datetime.date, str, bytes, int, float]
-    ) -> Union[datetime.date, str]:
+        cls, value: Union[FhirDateTime, datetime.date, str, bytes, int, float]
+    ) -> FhirDateTime:
         """ """
         if not isinstance(value, str):
             # default handler
-            return parse_date(value)
+            return FhirDateTime(value)
 
         match = FHIR_DATE_PARTS.match(value)
 
@@ -324,12 +325,10 @@ class Date(datetime.date, Primitive):
         elif not match.groupdict().get("day"):
             if match.groupdict().get("month") and int(match.groupdict()["month"]) > 12:
                 raise DateError()
-            # we keep original
-            return value
-        return parse_date(value)
+        return FhirDateTime(value)
 
 
-class DateTime(datetime.datetime, Primitive):
+class DateTime(FhirDateTime, Primitive):
     """A date, date-time or partial date (e.g. just year or year + month) as used
     in human communication. The format is YYYY, YYYY-MM, YYYY-MM-DD or
     YYYY-MM-DDThh:mm:ss+zz:zz, e.g. 2018, 1973-06, 1905-08-23,
@@ -356,15 +355,15 @@ class DateTime(datetime.datetime, Primitive):
 
     @classmethod
     def validate(
-        cls, value: Union[datetime.date, datetime.datetime, str, bytes, int, float]
-    ) -> Union[datetime.datetime, datetime.date, str]:
+        cls,
+        value: Union[
+            FhirDateTime, datetime.date, datetime.datetime, str, bytes, int, float
+        ],
+    ) -> FhirDateTime:
         """ """
-        if isinstance(value, datetime.date):
-            return value
-
-        if not isinstance(value, str):
+        if isinstance(value, datetime.date) or not isinstance(value, str):
             # default handler
-            return parse_datetime(value)
+            return FhirDateTime(value)
         match = FHIR_DATE_PARTS.match(value)
         if match:
             if (
@@ -372,19 +371,17 @@ class DateTime(datetime.datetime, Primitive):
                 and match.groupdict().get("month")
                 and match.groupdict().get("day")
             ):
-                return parse_date(value)
+                return FhirDateTime(value)
             elif match.groupdict().get("year") and match.groupdict().get("month"):
                 if int(match.groupdict()["month"]) > 12:
                     raise DateError()
-            # we don't want to loose actual information, so keep as string
-            return value
         if not cls.regex.match(value):
             raise DateTimeError()
 
-        return parse_datetime(value)
+        return FhirDateTime(value)
 
 
-class Instant(datetime.datetime, Primitive):
+class Instant(FhirDateTime, Primitive):
     """An instant in time in the format YYYY-MM-DDThh:mm:ss.sss+zz:zz
     (e.g. 2015-02-07T13:28:17.239+02:00 or 2017-01-01T00:00:00Z).
     The time SHALL specified at least to the second and SHALL include a time zone.
@@ -415,7 +412,7 @@ class Instant(datetime.datetime, Primitive):
         if isinstance(value, str):
             if not cls.regex.match(value):
                 raise DateTimeError()
-        return parse_datetime(value)
+        return FhirDateTime(value)
 
 
 class Time(datetime.time, Primitive):

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("README.rst") as readme_file:
 with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
-requirements = ["pydantic[email]>=1.7.2"]
+requirements = ["pydantic[email]>=1.7.2", "fhirdatetime>=0.1.0b8"]
 
 setup_requirements = ["pytest-runner"]
 


### PR DESCRIPTION
Re: #29

I tried to be very light-handed with changing the existing validators. It's possible that some of the remaining checks aren't necessary, but I didn't feel like that was my call. I've used the changes to `fhir.resources` in my own code with success. It's still possible that [`fhirdatetime`](https://github.com/mmabey/fhirdatetime) has some issues (in fact, I can see that many STU3 and R4 tests are [failing](https://travis-ci.com/github/mmabey/fhir.resources) with these changes), which is why I've created this as a draft PR. Looking forward to getting some feedback!