### PR TITLE
fixed url validation regex

### DIFF
--- a/fhir/resources/STU3/fhirtypes.py
+++ b/fhir/resources/STU3/fhirtypes.py
@@ -371,7 +371,7 @@ class Url(AnyUrl, Primitive):
     Common URL protocols are http{s}:, ftp:, mailto: and mllp:,
     though many others are defined"""
 
-    path_regex = re.compile(r"^/(?P<resourceType>[^\s?/]+)(/[^\s?/]+)*")
+    path_regex = re.compile(r"^\/?(?P<resourceType>[^\s?\/]+)(\/[^\s?\/]+)*")
     __visit_name__ = "url"
 
     @classmethod

--- a/fhir/resources/fhirtypes.py
+++ b/fhir/resources/fhirtypes.py
@@ -371,7 +371,7 @@ class Url(AnyUrl, Primitive):
     Common URL protocols are http{s}:, ftp:, mailto: and mllp:,
     though many others are defined"""
 
-    path_regex = re.compile(r"^/(?P<resourceType>[^\s?/]+)(/[^\s?/]+)*")
+    path_regex = re.compile(r"^\/?(?P<resourceType>[^\s?\/]+)(\/[^\s?\/]+)*")
     __visit_name__ = "url"
 
     @classmethod


### PR DESCRIPTION
This makes the leading slash in the URL regex optional, to comply with some vendors' interpretations of the standard