### PR TITLE
Replace the warning log with a warnings.warn instead.

### DIFF
--- a/fhir/resources/core/fhirabstractmodel.py
+++ b/fhir/resources/core/fhirabstractmodel.py
@@ -5,6 +5,7 @@ import inspect
 import logging
 import pathlib
 import typing
+import warnings
 from collections import OrderedDict
 from enum import Enum
 from functools import lru_cache
@@ -358,10 +359,14 @@ class FHIRAbstractModel(BaseModel, abc.ABC):
                     option |= orjson.OPT_SORT_KEYS
 
             if len(dumps_kwargs) > 0:
-                logger.debug(
+                # NOTE We will warn about the use of extra parameters passed
+                # into the `json()` call. However, this will only show once as
+                # it is likely it is the underlying application framework that
+                # is calling this function.
+                warnings.warn(
                     "When ``dumps`` method is used from ``orjson`` "
                     "all dumps kwargs are ignored except `indent`, `sort_keys` "
-                    "and of course ``option`` from orjson"
+                    "and of course ``option`` from orjson", stacklevel=2
                 )
                 dumps_kwargs = {}
 
@@ -411,11 +416,15 @@ class FHIRAbstractModel(BaseModel, abc.ABC):
         & https://github.com/nazrulworld/fhir.resources/issues/89
         """
         if len(pydantic_extra) > 0:
-            logger.warning(
+            # NOTE We will warn about the use of extra parameters passed
+            # into the `dict()` call. However, this will only show once as
+            # it is likely it is the underlying application framework that
+            # is calling this function.
+            warnings.warn(
                 f"{self.__class__.__name__}.dict method accepts only"
                 "´by_alias´, ´exclude_none´, ´exclude_comments` as parameters"
                 " since version v6.2.0, any extra parameter is simply ignored. "
-                "You should not provide any extra argument."
+                "You should not provide any extra argument.", stacklevel=2
             )
         return OrderedDict(
             self._fhir_iter(


### PR DESCRIPTION
As a result the warning is only issued once by default. A developer can choose to configure what warnings are filtered how.

Rationale: When using fhir.resources from an application framework such as fastapi, that expects to be able to use the Pydantic APIs for `dict()` and `json()` etc. the log will be "spammed" with warnings. The developer that uses the framework though has very limited control over this short of re configuring the log levels.