### PR TITLE
Fix #101 ElementDefinition.id typing is incorrect also on R4B package

### DIFF
--- a/fhir/resources/R4B/element.py
+++ b/fhir/resources/R4B/element.py
@@ -42,7 +42,7 @@ class Element(fhirabstractmodel.FHIRAbstractModel):
         element_property=True,
     )
 
-    id: fhirtypes.Id = Field(
+    id: fhirtypes.String = Field(
         None,
         alias="id",
         title="Unique id for inter-element referencing",


### PR DESCRIPTION
This add fix in https://github.com/nazrulworld/fhir.resources/issues/101 also R4B package.