### PR TITLE
Pydantic V2 API Migration

### DIFF
--- a/fhir/resources/core/utils/__init__.py
+++ b/fhir/resources/core/utils/__init__.py
@@ -3,12 +3,8 @@ import json
 import pathlib
 from typing import TYPE_CHECKING, Any, Callable, Union, cast, no_type_check, Optional
 
-from pydantic.v1.parse import Protocol
-from pydantic import load_file as default_load_file
-from pydantic.v1.parse import load_str_bytes as default_load_str_bytes
-from pydantic.v1.types import StrBytes
-
 from .common import is_primitive_type  # noqa: F401
+from .deprecated import Format, v1_load_str_bytes, v1_load_file
 
 try:
     from .yaml import yaml_dumps, yaml_loads
@@ -69,11 +65,11 @@ __author__ = "Md Nazrul Islam<email2nazrul@gmail.com>"
 
 
 def load_str_bytes(
-    b: StrBytes,
+    b: Union[str, bytes],
     *,
     content_type: Optional[str] = None,
     encoding: str = "utf8",
-    proto: Optional[Protocol] = None,
+    proto: Optional[Format] = None,
     allow_pickle: bool = False,
     json_loads: Callable[[str], Any] = json.loads,
     **extra,
@@ -95,7 +91,7 @@ def load_str_bytes(
                 b = cast(bytes, b)
             obj = xml_loads(extra["cls"], b, **params)
             return obj
-    obj = default_load_str_bytes(
+    obj = v1_load_str_bytes(
         b,
         proto=proto,  # type: ignore[arg-type]
         content_type=content_type,  # type: ignore[arg-type]
@@ -111,7 +107,7 @@ def load_file(
     *,
     content_type: Optional[str] = None,
     encoding: str = "utf8",
-    proto: Optional[Protocol] = None,
+    proto: Optional[Format] = None,
     allow_pickle: bool = False,
     json_loads: Callable[[str], Any] = json.loads,
     **extra,
@@ -136,7 +132,7 @@ def load_file(
             params["xmlparser"] = extra["xmlparser"]
         obj = xml_loads(extra["cls"], path.read_bytes(), **params)
     else:
-        obj = default_load_file(
+        obj = v1_load_file(
             path,
             proto=proto,  # type: ignore[arg-type]
             content_type=content_type,  # type: ignore[arg-type]

--- a/fhir/resources/core/utils/__init__.py
+++ b/fhir/resources/core/utils/__init__.py
@@ -4,7 +4,7 @@ import pathlib
 from typing import TYPE_CHECKING, Any, Callable, Union, cast, no_type_check, Optional
 
 from pydantic.v1.parse import Protocol
-from pydantic.v1.parse import load_file as default_load_file
+from pydantic import load_file as default_load_file
 from pydantic.v1.parse import load_str_bytes as default_load_str_bytes
 from pydantic.v1.types import StrBytes
 

--- a/fhir/resources/core/utils/common.py
+++ b/fhir/resources/core/utils/common.py
@@ -1,5 +1,8 @@
 # _*_ coding: utf-8 _*_
+from collections import deque
 from functools import lru_cache
+from types import GeneratorType
+from typing import Any
 
 from pydantic.v1.fields import ModelField
 from pydantic.v1.typing import get_args, get_origin
@@ -66,3 +69,7 @@ def normalize_fhir_type_class(type_):
                 return normalize_fhir_type_class(tp_)
     else:
         return type_
+
+
+def sequence_like(v: Any) -> bool:
+    return isinstance(v, (list, tuple, set, frozenset, GeneratorType, deque))

--- a/fhir/resources/core/utils/deprecated.py
+++ b/fhir/resources/core/utils/deprecated.py
@@ -1,0 +1,64 @@
+import json
+import pickle
+from enum import Enum
+from pathlib import Path
+from typing import Union, Callable, Any
+
+
+class Format(str, Enum):
+    json = 'json'
+    pickle = 'pickle'
+
+
+def v1_load_str_bytes(
+    b: Union[str, bytes],
+    *,
+    content_type: str = None,
+    encoding: str = 'utf8',
+    proto: Format = None,
+    allow_pickle: bool = False,
+    json_loads: Callable[[str], Any] = json.loads,
+) -> Any:
+    if proto is None and content_type:
+        if content_type.endswith(('json', 'javascript')):
+            pass
+        elif allow_pickle and content_type.endswith('pickle'):
+            proto = Format.pickle
+        else:
+            raise TypeError(f'Unknown content-type: {content_type}')
+
+    proto = proto or Format.json
+
+    if proto == Format.json:
+        if isinstance(b, bytes):
+            b = b.decode(encoding)
+        return json_loads(b)
+    elif proto == Format.pickle:
+        if not allow_pickle:
+            raise RuntimeError('Trying to decode with pickle with allow_pickle=False')
+        bb = b if isinstance(b, bytes) else b.encode()
+        return pickle.loads(bb)
+    else:
+        raise TypeError(f'Unknown protocol: {proto}')
+
+
+def v1_load_file(
+    path: Union[str, Path],
+    *,
+    content_type: str = None,
+    encoding: str = 'utf8',
+    proto: Format = None,
+    allow_pickle: bool = False,
+    json_loads: Callable[[str], Any] = json.loads,
+) -> Any:
+    path = Path(path)
+    b = path.read_bytes()
+    if content_type is None:
+        if path.suffix in ('.js', '.json'):
+            proto = Format.json
+        elif path.suffix == '.pkl':
+            proto = Format.pickle
+
+    return v1_load_str_bytes(
+        b, proto=proto, content_type=content_type, encoding=encoding, allow_pickle=allow_pickle, json_loads=json_loads
+    )


### PR DESCRIPTION
It looks like pydantic is quite thoroughly interleaved in `fhir.resources`. I haven't yet identified clear boundaries or individually migrate-able portions of the codebase. I think that we may have to collaborate commit by commit discussing how to navigate each breaking change.

Hopefully we can find a way to better encapsulate some of the fancy pydantic usage as we go.

I don't mind taking point on making sure this work/pr keeps moving forward, but I expect I'll need frequent input from @nazrulworld along the way.