### PR TITLE
switch the type of Element.id from id to string for R4B

### DIFF
--- a/fhir/resources/R4B/element.py
+++ b/fhir/resources/R4B/element.py
@@ -43,7 +43,7 @@ class Element(fhirabstractmodel.FHIRAbstractModel):
         },
     )
 
-    id: fhirtypes.IdType | None = Field(  # type: ignore
+    id: fhirtypes.StringType | None = Field(  # type: ignore
         None,
         alias="id",
         title="Unique id for inter-element referencing",


### PR DESCRIPTION
According to the FHIR documentation `Element.id` should be of type `string`.

StructureDefinitions with type slicing will have entries in the differential and snapshot part in the format  like `Observation.category:VSCat`. This is valid according to the specification. But before the element was of type `id` which caused validation errors when parsing StructureDefinitions like this.