### PR TITLE
switch the type of Element.id from id to string for R4B in 7.x.x

### DIFF
--- a/fhir/resources/R4B/element.py
+++ b/fhir/resources/R4B/element.py
@@ -42,7 +42,7 @@ class Element(fhirabstractmodel.FHIRAbstractModel):
         element_property=True,
     )
 
-    id: fhirtypes.Id = Field(
+    id: fhirtypes.String = Field(
         None,
         alias="id",
         title="Unique id for inter-element referencing",


### PR DESCRIPTION
Fix #159 for 7.x.x similar to #160 