### PR TITLE
Fix CI workflow and add steps to run tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,18 +22,41 @@ jobs:
       fail-fast: true
       max-parallel: 4
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
-      - name: Setup Python ${{ matrix.python-version }}
-        id: setup-python
-        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+      - name: Install uv
+        uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
+        id: setup-uv
         with:
           python-version: ${{ matrix.python-version }}
+          activate-environment: true
       - name: Install dependencies
         run: |
-            pip install -e .[dev]
-      - run: make lint
-      - run: black --check fhir/resources/
+          uv run python --version
+          uv pip install -e .[test]
+      - run: uv run flake8 ./fhir/resources/
+      - run: uv run black --check fhir/resources/
+      # monthly cache updates
+      - run: echo "cache_id=$(date --utc '+%m')" >> "$GITHUB_ENV"
+      - uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+        with:
+          key: fhir-resources-${{ env.cache_id }}
+          path: .cache
+          restore-keys: |
+            fhir-resources-
+      - name: Run main tests with Python ${{ matrix.python-version }}
+        run: |
+          which pytest
+          uv run pytest tests
+      - name: Run STU3 tests with Python ${{ matrix.python-version }}
+        run: |
+          uv run pytest fhir/resources/STU3/tests
+      - name: Run R4B tests with Python ${{ matrix.python-version }}
+        run: |
+          uv run pytest -s --cov=fhir/resources/R4B/tests -s --tb=native -v --cov-report term-missing --cov-append fhir/resources/R4B/tests
+      - name: Run R5 tests with Python ${{ matrix.python-version }}
+        run: |
+          uv run pytest -s --cov=fhir/resources/tests -s --tb=native -v --cov-report term-missing --cov-append fhir/resources/tests

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ test_requirements = [
     "coverage",
     "pytest>5.4.0;python_version>='3.6'",
     "pytest-cov>=2.10.0;python_version>='3.6'",
-    "flake8" + (PY_VERSION_10_OR_LATER and "==6.0" or "==5.0.4;python_version<'3.10'"),
+    "flake8" + (PY_VERSION_10_OR_LATER and "==7.3.0" or "==5.0.4;python_version<'3.10'"),
     "flake8-isort"
     + (PY_VERSION_10_OR_LATER and ">=6.0.0" or "==4.2.0;python_version<'3.10'"),
     "flake8-bugbear"

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ test_requirements = [
     + (PY_VERSION_10_OR_LATER and ">=6.0.0" or "==4.2.0;python_version<'3.10'"),
     "flake8-bugbear"
     + (PY_VERSION_10_OR_LATER and ">=22.12.6" or "==20.1.4;python_version<'3.10'"),
-    "requests==2.23.0;python_version<'3.10'",
+    "requests==2.32.4",
     "isort" + (PY_VERSION_10_OR_LATER and ">=5.11.4" or "==4.3.21"),
     "black>=23.0,<24.0; python_version >= '3.7'",
     "mypy",
@@ -48,8 +48,6 @@ test_requirements = [
 ]
 if PY_VERSION_10_OR_LATER:
     test_requirements.append("importlib-metadata>=5.2.0")
-if PY_VERSION_11_OR_LATER:
-    test_requirements.append("typed-ast>=1.5.4")
 
 development_requirements = [
     "Jinja2==3.1.6",

--- a/tests/test_xml_validate_and_dump.py
+++ b/tests/test_xml_validate_and_dump.py
@@ -1,7 +1,7 @@
 import sys
 from http import client
 
-import lxml.etree  # type: ignore
+import lxml.etree
 from fhir_core import xml_utils
 
 from fhir.resources.R4B.observation import Observation

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,7 +2,7 @@ import logging
 import subprocess
 import sys
 from http import client
-from typing import Union
+from typing import Optional, Union
 
 from fhir_core import xml_utils
 from fhir_core.fhirabstractmodel import FHIRAbstractModel
@@ -21,9 +21,9 @@ def has_internet_connection():
         return False
 
 
-def post_xml_resource(  # type: ignore
+def post_xml_resource(
     conn: client.HTTPConnection, resource: Union[xml_utils.Node, FHIRAbstractModel]
-) -> client.HTTPResponse:
+) -> Optional[client.HTTPResponse]:
     """ """
     if isinstance(resource, FHIRAbstractModel):
         resource_str = resource.model_dump_xml(return_bytes=True, pretty_print=False)
@@ -48,3 +48,5 @@ def post_xml_resource(  # type: ignore
         return response
     except client.HTTPException as exc:
         sys.stderr.write(f"{exc}\n")
+
+    return None


### PR DESCRIPTION
Follow-up to #194

Uses `uv` to set up venv and install dependencies.
Adds missing steps for tests.