### PR TITLE
fix: enforce Extension.url required validation per FHIR spec (Fixes #205)

### DIFF
--- a/fhir/resources/R4B/extension.py
+++ b/fhir/resources/R4B/extension.py
@@ -10,7 +10,8 @@ from __future__ import annotations as _annotations
 
 import typing
 
-from pydantic import Field
+from pydantic import Field, model_validator
+from pydantic_core import PydanticCustomError
 
 from . import element, fhirtypes
 
@@ -25,6 +26,26 @@ class Extension(element.Element):
     """
 
     __resource_type__ = "Extension"
+
+    @model_validator(mode="after")
+    def validate_url_required(self) -> "Extension":
+        """Extension.url is required per FHIR spec (cardinality 1..1)."""
+        if self.url is None:
+            has_value = any(
+                getattr(self, name, None) is not None
+                for name in self.__class__.model_fields
+                if name.startswith("value")
+            )
+            has_nested_extensions = (
+                self.extension is not None and len(self.extension) > 0
+            )
+            if has_value or has_nested_extensions:
+                raise PydanticCustomError(
+                    "fhir_validation_required",
+                    "Extension.url is required (FHIR cardinality 1..1).",
+                    {},
+                )
+        return self
 
     url: fhirtypes.UriType | None = Field(
         default=None,

--- a/fhir/resources/STU3/extension.py
+++ b/fhir/resources/STU3/extension.py
@@ -10,7 +10,8 @@ from __future__ import annotations as _annotations
 
 import typing
 
-from pydantic import Field
+from pydantic import Field, model_validator
+from pydantic_core import PydanticCustomError
 
 from . import element, fhirtypes
 
@@ -25,6 +26,26 @@ class Extension(element.Element):
     """
 
     __resource_type__ = "Extension"
+
+    @model_validator(mode="after")
+    def validate_url_required(self) -> "Extension":
+        """Extension.url is required per FHIR spec (cardinality 1..1)."""
+        if self.url is None:
+            has_value = any(
+                getattr(self, name, None) is not None
+                for name in self.__class__.model_fields
+                if name.startswith("value")
+            )
+            has_nested_extensions = (
+                self.extension is not None and len(self.extension) > 0
+            )
+            if has_value or has_nested_extensions:
+                raise PydanticCustomError(
+                    "fhir_validation_required",
+                    "Extension.url is required (FHIR cardinality 1..1).",
+                    {},
+                )
+        return self
 
     url: fhirtypes.UriType | None = Field(
         default=None,

--- a/fhir/resources/extension.py
+++ b/fhir/resources/extension.py
@@ -10,7 +10,8 @@ from __future__ import annotations as _annotations
 
 import typing
 
-from pydantic import Field
+from pydantic import Field, model_validator
+from pydantic_core import PydanticCustomError
 
 from . import datatype, fhirtypes
 
@@ -25,6 +26,26 @@ class Extension(datatype.DataType):
     """
 
     __resource_type__ = "Extension"
+
+    @model_validator(mode="after")
+    def validate_url_required(self) -> "Extension":
+        """Extension.url is required per FHIR spec (cardinality 1..1)."""
+        if self.url is None:
+            has_value = any(
+                getattr(self, name, None) is not None
+                for name in self.__class__.model_fields
+                if name.startswith("value")
+            )
+            has_nested_extensions = (
+                self.extension is not None and len(self.extension) > 0
+            )
+            if has_value or has_nested_extensions:
+                raise PydanticCustomError(
+                    "fhir_validation_required",
+                    "Extension.url is required (FHIR cardinality 1..1).",
+                    {},
+                )
+        return self
 
     url: fhirtypes.UriType | None = Field(
         default=None,

--- a/tests/test_extension_url_required.py
+++ b/tests/test_extension_url_required.py
@@ -1,0 +1,95 @@
+"""Tests for Extension.url required validation (issue #205)."""
+import pytest
+from pydantic import ValidationError
+
+
+class TestExtensionUrlRequired:
+    """Extension.url must be present per FHIR spec cardinality 1..1."""
+
+    def test_r4b_extension_with_value_requires_url(self):
+        """Extension with value[x] but no url should fail validation."""
+        from fhir.resources.R4B.patient import Patient
+
+        with pytest.raises(ValidationError, match="Extension.url is required"):
+            Patient.model_validate(
+                {
+                    "resourceType": "Patient",
+                    "extension": [{"valueCode": "F"}],
+                }
+            )
+
+    def test_r5_extension_with_value_requires_url(self):
+        """R5 Extension with value[x] but no url should fail validation."""
+        from fhir.resources.patient import Patient
+
+        with pytest.raises(ValidationError, match="Extension.url is required"):
+            Patient.model_validate(
+                {
+                    "resourceType": "Patient",
+                    "extension": [{"valueCode": "F"}],
+                }
+            )
+
+    def test_stu3_extension_with_value_requires_url(self):
+        """STU3 Extension with value[x] but no url should fail validation."""
+        from fhir.resources.STU3.patient import Patient
+
+        with pytest.raises(ValidationError, match="Extension.url is required"):
+            Patient.model_validate(
+                {
+                    "resourceType": "Patient",
+                    "extension": [{"valueCode": "F"}],
+                }
+            )
+
+    def test_r4b_valid_extension_with_url(self):
+        """Extension with url and value should pass."""
+        from fhir.resources.R4B.patient import Patient
+
+        p = Patient.model_validate(
+            {
+                "resourceType": "Patient",
+                "extension": [
+                    {"url": "http://example.com/ext", "valueCode": "F"}
+                ],
+            }
+        )
+        assert p.extension[0].url == "http://example.com/ext"
+        assert p.extension[0].valueCode == "F"
+
+    def test_r4b_extension_url_only(self):
+        """Extension with only url (no value) should pass."""
+        from fhir.resources.R4B.patient import Patient
+
+        p = Patient.model_validate(
+            {
+                "resourceType": "Patient",
+                "extension": [{"url": "http://example.com/ext"}],
+            }
+        )
+        assert p.extension[0].url == "http://example.com/ext"
+
+    def test_r4b_extension_nested_requires_url(self):
+        """Extension with nested extensions but no url should fail."""
+        from fhir.resources.R4B.patient import Patient
+
+        with pytest.raises(ValidationError, match="Extension.url is required"):
+            Patient.model_validate(
+                {
+                    "resourceType": "Patient",
+                    "extension": [
+                        {
+                            "extension": [
+                                {"url": "http://nested", "valueString": "test"}
+                            ]
+                        }
+                    ],
+                }
+            )
+
+    def test_r4b_value_string_requires_url(self):
+        """Extension with valueString but no url should fail."""
+        from fhir.resources.R4B.extension import Extension
+
+        with pytest.raises(ValidationError, match="Extension.url is required"):
+            Extension.model_validate({"valueString": "test"})


### PR DESCRIPTION
Fixes #205

## Problem

FHIR Extension.url has cardinality 1..1 in the spec — it is always required. The model had `"element_required": True` in `json_schema_extra` metadata, but Pydantic v2 does not enforce custom metadata during validation. The field also had `default=None`, making it effectively optional.

This allowed invalid data like `{"valueCode": "F"}` (no url) to pass validation:

```python
from fhir.resources.R4B.patient import Patient
Patient.model_validate({
    "resourceType": "Patient",
    "extension": [{"valueCode": "F"}],
})  # Succeeds — should fail
```

## Solution

Added a `model_validator(mode='after')` to `Extension` in all three FHIR versions (R4B, R5, STU3) that raises `ValidationError` when an Extension has `value[x]` fields or nested extensions but no `url`. Empty extensions (no url, no value) are tolerated for backward compatibility.

## Verification

```
tests/test_extension_url_required.py::TestExtensionUrlRequired::test_r4b_extension_with_value_requires_url PASSED
tests/test_extension_url_required.py::TestExtensionUrlRequired::test_r5_extension_with_value_requires_url PASSED
tests/test_extension_url_required.py::TestExtensionUrlRequired::test_stu3_extension_with_value_requires_url PASSED
tests/test_extension_url_required.py::TestExtensionUrlRequired::test_r4b_valid_extension_with_url PASSED
tests/test_extension_url_required.py::TestExtensionUrlRequired::test_r4b_extension_url_only PASSED
tests/test_extension_url_required.py::TestExtensionUrlRequired::test_r4b_extension_nested_requires_url PASSED
tests/test_extension_url_required.py::TestExtensionUrlRequired::test_r4b_value_string_requires_url PASSED
tests/test_summary_mode_serialization.py::test_summary_for_model_serialization PASSED
tests/test_summary_mode_serialization.py::test_summary_for_json_serialization PASSED
tests/test_summary_mode_serialization.py::test_summary_for_xml_serialization PASSED
tests/test_summary_mode_serialization.py::test_summary_for_yaml_serialization PASSED
tests/test_xml_validate_and_dump.py::test_xml_node_patient_resource PASSED
tests/test_xml_validate_and_dump.py::test_xml_node_observation_resource PASSED
tests/test_xml_validate_and_dump.py::test_element_to_node PASSED
tests/test_xml_validate_and_dump.py::test_model_obj_xml_file PASSED
tests/test_yaml_validate_and_dump.py::test_yaml_patient_resource PASSED

16 passed in 0.54s
```

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **mimo-2.5-pro** (Xiaomi) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
